### PR TITLE
Add support for 2FA

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ring alarm hassio integration",
-  "version": "0.52",
+  "version": "0.53",
   "slug": "ring_alarm",
   "description": "Ring Alarm Integration! uses https://github.com/tsightler/ring-alarm-mqtt",
   "startup": "before",
@@ -21,6 +21,7 @@
     "mqtt_pass": "",
     "ring_user": "ring_email",
     "ring_pass": "ring_password"
+    "ring_token": "ring_token",
   },
   "schema": {
    "host": "str",

--- a/config.json
+++ b/config.json
@@ -21,7 +21,8 @@
     "mqtt_pass": "",
     "ring_user": "ring_email",
     "ring_pass": "ring_password",
-    "ring_token": "ring_token"
+    "ring_token": "ring_token",
+    "location_ids": [""]
   },
   "schema": {
    "host": "str",
@@ -32,6 +33,7 @@
     "mqtt_pass": "str",
     "ring_user": "str",
     "ring_pass": "str",
-    "ring_token": "str"
+    "ring_token": "str",
+    "location_ids": ["str"]  
   }
 }

--- a/config.json
+++ b/config.json
@@ -31,6 +31,7 @@
     "mqtt_user": "str",
     "mqtt_pass": "str",
     "ring_user": "str",
-    "ring_pass": "str"
+    "ring_pass": "str",
+    "ring_token": "str"
   }
 }

--- a/config.json
+++ b/config.json
@@ -20,8 +20,8 @@
     "mqtt_user": "",
     "mqtt_pass": "",
     "ring_user": "ring_email",
-    "ring_pass": "ring_password"
-    "ring_token": "ring_token",
+    "ring_pass": "ring_password",
+    "ring_token": "ring_token"
   },
   "schema": {
    "host": "str",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ring alarm hassio integration",
-  "version": "0.53",
+  "version": "0.54",
   "slug": "ring_alarm",
   "description": "Ring Alarm Integration! uses https://github.com/tsightler/ring-alarm-mqtt",
   "startup": "before",

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ring alarm hassio integration",
-  "version": "0.54",
+  "version": "0.55",
   "slug": "ring_alarm",
   "description": "Ring Alarm Integration! uses https://github.com/tsightler/ring-alarm-mqtt",
   "startup": "before",
@@ -19,9 +19,9 @@
     "hass_topic": "hass/status",
     "mqtt_user": "",
     "mqtt_pass": "",
-    "ring_user": "ring_email",
-    "ring_pass": "ring_password",
-    "ring_token": "ring_token",
+    "ring_user": "",
+    "ring_pass": "",
+    "ring_token": "",
     "location_ids": [""]
   },
   "schema": {

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Ring Alarm HASSIO Addon",
-  "maintainer": "RS"
+  "maintainer": "RS/broyuken"
   
 }


### PR DESCRIPTION
Added the additional fields to pass into the https://github.com/tsightler/ring-alarm-mqtt/ script. Note you need to follow the steps in https://github.com/dgreif/ring/wiki/Two-Factor-Auth in order to generate a token for use in this script.